### PR TITLE
Add support for a custom filesystem binary.

### DIFF
--- a/dir2uf2
+++ b/dir2uf2
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import os
+import sys
 import math
 import argparse
 import struct
@@ -106,6 +107,7 @@ parser = argparse.ArgumentParser()
 parser.add_argument("--filename", type=pathlib.Path, default="filesystem", help="Output filename.")
 parser.add_argument("--fs-start", type=int, default=None, help="Filesystem offset.")
 parser.add_argument("--fs-size", type=int, default=None, help="Filesystem size.")
+parser.add_argument("--fs-reserve", type=int, default=0, help="Size (in bytes) to reserve for other functions.")
 parser.add_argument("--fs-compact", action="store_true", help="Compact filesystem to used blocks.")
 parser.add_argument("--fs-overwrite", action="store_true", help="Replace an existing filesystem in the UF2.")
 parser.add_argument("--sparse", action="store_true", help="Skip padding between app and filesystem.")
@@ -135,10 +137,20 @@ if args.fs_start is None or args.fs_size is None:
         print(f"Auto detected fs: 0x{args.fs_start:08x} ({args.fs_start}), {args.fs_size} bytes.")
         break
 
+    # Apply filesystem size correction by removing reserved byte-count
+    # Allows us to use auto-detect, but also leave some amount of storage
+    # for a secondary (Fat vs LittleFS hybrid) filesystem.
+    if args.fs_reserve != math.ceil(args.fs_reserve / args.block_size) * args.block_size:
+        print("fs_reserve must be a multiple of block size!")
+        sys.exit(1)
+    args.fs_size -= args.fs_reserve
+    if args.fs_reserve > 0:
+        print(f"Reserving {args.fs_reserve / 1024}Kb!")
+
 block_count = math.ceil(args.fs_size / args.block_size)
 if block_count * args.block_size != args.fs_size:
-    print("image size should be a multiple of block size")
-    exit(1)
+    print("image size must be a multiple of block size!")
+    sys.exit(1)
 
 output_filename = args.filename
 

--- a/dir2uf2
+++ b/dir2uf2
@@ -116,7 +116,7 @@ parser.add_argument("--manifest", default=None, help="Manifest to filter copied 
 parser.add_argument("--append-to", type=pathlib.Path, default=None, help="uf2 file to append filesystem.")
 parser.add_argument("--debug", action="store_true", help="Debug output.")
 parser.add_argument("--verbose", action="store_true", help="Verbose output.")
-parser.add_argument("source_dir", type=pathlib.Path, help="Source directory.")
+parser.add_argument("source_dir", type=pathlib.Path, help="Source directory or file.")
 args = parser.parse_args()
 
 if args.fs_start is None or args.fs_size is None:
@@ -140,82 +140,89 @@ if block_count * args.block_size != args.fs_size:
     print("image size should be a multiple of block size")
     exit(1)
 
-lfs = littlefs.LittleFS(
-    block_size=args.block_size,
-    block_count=block_count,
-    read_size=args.read_size,
-    prog_size=args.prog_size,
-)
-
 output_filename = args.filename
 
 
-def copy_files(lfs, todo, source_dir):
-    for src in todo:
-        if src.is_dir():
-            dst = src.relative_to(source_dir)
-            if args.verbose:
-                print(f"- mkdir: {dst}")
-            lfs.makedirs(dst.as_posix().replace("\\", "/"), exist_ok=True)
-        if src.is_file():
-            dst = src.relative_to(source_dir)
-            if args.verbose:
-                print(f"- copy: {src} to {dst}")
-            with lfs.open(dst.as_posix().replace("\\", "/"), "wb") as outfile:
-                with open(src, "rb") as infile:
-                    outfile.write(infile.read())
-
-
-def copy_manifest_or_dir(lfs, source_dir):
-    if args.manifest is None:
-        print(f"Copying directory: {source_dir}")
-        # Walk the entire source dir and copy *everything*
-        search_path = os.path.join("**", "*")
-        copy_files(lfs, source_dir.glob(search_path), source_dir)
-
-    else:
-        print(f"Using manifest: {args.manifest}")
-        # Copy files/globs listed in the manifest relative to the source dir
-        todo = [line.strip() for line in open(args.manifest, "r").readlines() if line.strip()]
-        for item in todo:
-            parent_dir = pathlib.Path(item).parent
-            lfs.makedirs(str(parent_dir), exist_ok=True)
-            copy_files(lfs, source_dir.glob(item), source_dir)
-
-
-copy_manifest_or_dir(lfs, args.source_dir)
-
-# Write a .bin with *just* the filesystem
-bin_filename = output_filename.with_suffix(".bin")
-lfs_used_bytes = len(lfs.context.buffer)
-
-if args.fs_compact:
-    lfs_used_bytes = lfs.used_block_count * args.block_size
-
-    print(f"Compacting LittleFS to {lfs_used_bytes / 1024}K.")
-
-    lfs_compact = littlefs.LittleFS(
+# Build a LittleFS filesystem by default if a directory is supplied
+if args.source_dir.is_dir():
+    lfs = littlefs.LittleFS(
         block_size=args.block_size,
-        block_count=lfs.used_block_count,
+        block_count=block_count,
         read_size=args.read_size,
         prog_size=args.prog_size,
     )
 
-    copy_manifest_or_dir(lfs_compact, args.source_dir)
+    def copy_files(lfs, todo, source_dir):
+        for src in todo:
+            if src.is_dir():
+                dst = src.relative_to(source_dir)
+                if args.verbose:
+                    print(f"- mkdir: {dst}")
+                lfs.makedirs(dst.as_posix().replace("\\", "/"), exist_ok=True)
+            if src.is_file():
+                dst = src.relative_to(source_dir)
+                if args.verbose:
+                    print(f"- copy: {src} to {dst}")
+                with lfs.open(dst.as_posix().replace("\\", "/"), "wb") as outfile:
+                    with open(src, "rb") as infile:
+                        outfile.write(infile.read())
 
-    lfs_compact.fs_grow(block_count)
 
-    lfs_data = lfs_compact.context.buffer
+    def copy_manifest_or_dir(lfs, source_dir):
+        if args.manifest is None:
+            print(f"Copying directory: {source_dir}")
+            # Walk the entire source dir and copy *everything*
+            search_path = os.path.join("**", "*")
+            copy_files(lfs, source_dir.glob(search_path), source_dir)
+
+        else:
+            print(f"Using manifest: {args.manifest}")
+            # Copy files/globs listed in the manifest relative to the source dir
+            todo = [line.strip() for line in open(args.manifest, "r").readlines() if line.strip()]
+            for item in todo:
+                parent_dir = pathlib.Path(item).parent
+                lfs.makedirs(str(parent_dir), exist_ok=True)
+                copy_files(lfs, source_dir.glob(item), source_dir)
+
+
+    copy_manifest_or_dir(lfs, args.source_dir)
+
+    # Write a .bin with *just* the filesystem
+    bin_filename = output_filename.with_suffix(".bin")
+    lfs_used_bytes = len(lfs.context.buffer)
+
+    if args.fs_compact:
+        lfs_used_bytes = lfs.used_block_count * args.block_size
+
+        print(f"Compacting LittleFS to {lfs_used_bytes / 1024}K.")
+
+        lfs_compact = littlefs.LittleFS(
+            block_size=args.block_size,
+            block_count=lfs.used_block_count,
+            read_size=args.read_size,
+            prog_size=args.prog_size,
+        )
+
+        copy_manifest_or_dir(lfs_compact, args.source_dir)
+
+        lfs_compact.fs_grow(block_count)
+
+        lfs_data = lfs_compact.context.buffer
+
+    else:
+        lfs_data = lfs.context.buffer
+
+
+    with open(bin_filename, "wb") as f:
+        f.write(lfs_data)
+
+    print(f"Written: {bin_filename}")
+
+elif args.source_dir.is_file():  # Open an existing filesystem binary
+    lfs_data = open(args.source_dir, "rb").read()
 
 else:
-    lfs_data = lfs.context.buffer
-
-
-with open(bin_filename, "wb") as f:
-    f.write(lfs_data)
-
-print(f"Written: {bin_filename}")
-
+    raise RuntimeError("Source directory or file required!")
 
 # Write a .uf2 with *just* the filesystem
 uf2_filename = output_filename.with_suffix(".uf2")


### PR DESCRIPTION
If a file is supplied in lieu of a directory, it will be treated as a packed filesystem and appended as normal- skipping the LittleFS build steps.

TODO: Make this work with ROMFS, too, assuming it has a `bi_decl` that lets us locate it.